### PR TITLE
Fix tooltip positioning within elements with height or width of 0

### DIFF
--- a/Tooltip.jsx
+++ b/Tooltip.jsx
@@ -31,6 +31,7 @@ function getHalfDimensions(element) {
         if (element.height && type === 'height') {
             return element.height / 2;
         }
+        return 0;
     };
 }
 


### PR DESCRIPTION
In a Backbone-style [TemplateView](https://www.npmjs.com/package/template-view), subviews can be rendered into an empty placeholder element (i.e. width=0, height=0) in the template. The logic in `getHalfDimensions` depends on the element's width and height dimensions, but because `0` (the value for both height and width in the placeholder element) is interpreted as falsy, `getHalfDimensions` returns `undefined` instead of the expected `0`.

**TL;DR:**

 `0 / 2 = 0` but if `element.width` or `element.height` is `0`, `getHalfDimensions` will return `undefined`